### PR TITLE
PAE-1194: Add post-test org cleanup to prevent data pollution

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,35 @@
 
 echo "run_id: $RUN_ID in $ENVIRONMENT"
 
+# Best-effort cleanup of every orgId the test suite created. Runs regardless
+# of pass/fail — we still want to delete data from failed runs. See PAE-1194.
+cleanup_created_orgs() {
+  id_file="/opt/perftest/test-artifacts/created-org-ids.txt"
+  if [ ! -s "$id_file" ]; then
+    echo "cleanup: no IDs to clean up"
+    return 0
+  fi
+  if [ -z "$ENVIRONMENT" ]; then
+    echo "cleanup: ENVIRONMENT not set; skipping"
+    return 0
+  fi
+  backend_url="https://epr-backend.${ENVIRONMENT}.cdp-int.defra.cloud"
+  total=$(wc -l < "$id_file" | tr -d ' ')
+  echo "cleanup: deleting $total orgs via $backend_url"
+  fail=0
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    status=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X DELETE "$backend_url/v1/dev/organisations/$id" || echo "000")
+    echo "  cleanup: $id -> $status"
+    [ "$status" = "200" ] || fail=$((fail + 1))
+  done < "$id_file"
+  echo "cleanup: complete. failures: $fail / $total"
+  return 0
+}
+
+trap 'cleanup_created_orgs' EXIT
+
 NOW=$(date +"%Y%m%d-%H%M%S")
 
 if [ -z "${JM_HOME}" ]; then

--- a/scenarios/epr-backend-test.jmx
+++ b/scenarios/epr-backend-test.jmx
@@ -1686,6 +1686,19 @@ vars.put(&quot;userOrgId&quot;, userOrgId);
               <stringProp name="Scope.variable"></stringProp>
             </JSONPostProcessor>
             <hashTree/>
+            <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Track orgId for cleanup" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def orgId = vars.get(&quot;orgId&quot;)
+if (orgId) {
+    def dir = new File(&quot;/opt/perftest/test-artifacts&quot;)
+    if (!dir.exists()) dir.mkdirs()
+    new File(&quot;/opt/perftest/test-artifacts/created-org-ids.txt&quot;).append(orgId + &quot;\n&quot;)
+}</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223PostProcessor>
+            <hashTree/>
           </hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Registration Details HTTP Request" enabled="true">
             <stringProp name="HTTPSampler.domain">${EPR_BACKEND_HOST}</stringProp>


### PR DESCRIPTION
## Summary

- Adds a JSR223 PostProcessor (Groovy) to `epr-backend-test.jmx` immediately after the `refNo JSON Extractor` — records each `orgId` to `/opt/perftest/test-artifacts/created-org-ids.txt` after every successful org creation
- Adds `cleanup_created_orgs()` to `entrypoint.sh` with an EXIT trap so orgs are deleted via `DELETE /v1/dev/organisations/{id}` after the run, regardless of pass/fail; skips if `ENVIRONMENT` is not set

## Test plan

- [ ] Verify the branch runs cleanly in CI
- [ ] Confirm shared environment orgs are cleaned up after a test run by checking the cleanup log output